### PR TITLE
Linear-interpolated lighting

### DIFF
--- a/src/shaders/flat.frag
+++ b/src/shaders/flat.frag
@@ -13,13 +13,19 @@ in float v_dist;
 const float WORLD_TO_PIXEL = 100.0;
 const float TILE_SIZE = 64.0;
 const float LIGHT_SCALE = 1.75;
-const float LIGHT_BIAS = 1e-4;
+const float LIGHT_BIAS = 1e-5;
 
 void main() {
     vec2 uv = mod(-v_pos.xz * WORLD_TO_PIXEL, TILE_SIZE) + v_offset;
     float palette_index = texture(u_atlas, uv / u_atlas_size).r;
     float dist_term = min(1.0, 1.0 - 1.2 / (v_dist + 1.2));
     float light = min(v_light, v_light * LIGHT_SCALE - dist_term);
-    light = 1.0 - clamp(light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
-    color = texture(u_palette, vec2(palette_index, light)).rgb;
+
+    light = clamp(light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
+
+    // Palettized lighting:
+    //color = texture(u_palette, vec2(palette_index, 1.0 - light)).rgb;
+
+    // Linear interpolated lighting:
+    color = texture(u_palette, vec2(palette_index, 0.0)).rgb * vec3(light, light, light);
 }

--- a/src/shaders/flat.frag
+++ b/src/shaders/flat.frag
@@ -12,13 +12,14 @@ in float v_dist;
 
 const float WORLD_TO_PIXEL = 100.0;
 const float TILE_SIZE = 64.0;
-const float LIGHT_BIAS = 1e-5;
+const float LIGHT_SCALE = 1.75;
+const float LIGHT_BIAS = 1e-4;
 
 void main() {
-    vec2 uv = mod(v_pos.xz * WORLD_TO_PIXEL, TILE_SIZE) + v_offset;
+    vec2 uv = mod(-v_pos.xz * WORLD_TO_PIXEL, TILE_SIZE) + v_offset;
     float palette_index = texture(u_atlas, uv / u_atlas_size).r;
-    float dist_term = clamp(0.0, 1.0, 1.0 - 1.2 / (v_dist + 1.2));
-    float light = clamp(0.0, v_light, v_light - dist_term);
+    float dist_term = min(1.0, 1.0 - 1.2 / (v_dist + 1.2));
+    float light = min(v_light, v_light * LIGHT_SCALE - dist_term);
     light = 1.0 - clamp(light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
     color = texture(u_palette, vec2(palette_index, light)).rgb;
 }

--- a/src/shaders/flat.vert
+++ b/src/shaders/flat.vert
@@ -77,6 +77,7 @@ void main() {
   v_light = light_level() * 1.0 / 31.0;
 
   vec4 projected_pos = u_transform * vec4(a_pos, 1);
+
   v_dist = projected_pos.w;
   gl_Position = projected_pos;
 }

--- a/src/shaders/flat.vert
+++ b/src/shaders/flat.vert
@@ -74,7 +74,7 @@ void main() {
           a_atlas_uv.y + floor(atlas_u / u_atlas_size.x) * TILE_SIZE;
       v_offset = vec2(atlas_u, atlas_v);
   }
-  v_light = light_level() * 2.0 / 31.0;
+  v_light = light_level() * 1.0 / 31.0;
 
   vec4 projected_pos = u_transform * vec4(a_pos, 1);
   v_dist = projected_pos.w;

--- a/src/shaders/sky.frag
+++ b/src/shaders/sky.frag
@@ -10,7 +10,7 @@ in vec4 v_p;
 
 void main() {
     vec2 uv = vec2(v_p.x, v_p.y) / v_p.w * vec2(1, -1);
-    uv = vec2(uv.x - 4.0 * v_r.x / 3.14159, uv.y + 1.0 + v_r.y);
+    uv = vec2(uv.x - 4.0 * v_r.x / 3.14159265358, uv.y + 1.0 + v_r.y);
     if (uv.y < 0.0) {
         uv.y = abs(mod(-uv.y + u_tiled_band_size,
                        u_tiled_band_size * 2) - u_tiled_band_size);

--- a/src/shaders/wall.frag
+++ b/src/shaders/wall.frag
@@ -11,8 +11,9 @@ flat in vec2 v_atlas_uv;
 flat in float v_tile_width;
 flat in float v_light;
 
-const float LIGHT_BIAS = 1e-4;
 const float TILE_HEIGHT = 128.0;
+const float LIGHT_SCALE = 1.75;
+const float LIGHT_BIAS = 1e-4;
 
 void main() {
     vec2 uv = mod(v_tile_uv, vec2(v_tile_width, TILE_HEIGHT)) + v_atlas_uv;
@@ -21,7 +22,7 @@ void main() {
         discard;
     } else {
         float dist_term = min(1.0, 1.0 - 1.2 / (v_dist + 1.2));
-        float light = min(v_light, v_light - dist_term);
+        float light = min(v_light, v_light * LIGHT_SCALE - dist_term);
         light = clamp(1.0 - light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
         color = texture(u_palette, vec2(palette_index.r, light)).rgb;
     }

--- a/src/shaders/wall.frag
+++ b/src/shaders/wall.frag
@@ -23,7 +23,13 @@ void main() {
     } else {
         float dist_term = min(1.0, 1.0 - 1.2 / (v_dist + 1.2));
         float light = min(v_light, v_light * LIGHT_SCALE - dist_term);
-        light = clamp(1.0 - light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
-        color = texture(u_palette, vec2(palette_index.r, light)).rgb;
+
+        light = clamp(light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
+
+        // Palettized lighting:
+        //color = texture(u_palette, vec2(palette_index.r, 1.0 - light)).rgb;
+
+        // Linear interpolated lighting:
+        color = texture(u_palette, vec2(palette_index.r, 0.0)).rgb * vec3(light, light, light);
     }
 }

--- a/src/shaders/wall.vert
+++ b/src/shaders/wall.vert
@@ -79,7 +79,7 @@ void main() {
         v_atlas_uv = vec2(atlas_u, atlas_v);
     }
     v_tile_width = a_tile_width;
-    v_light = light_level() * 2.0 / 31.0;
+    v_light = light_level() * 1.0 / 31.0;
     vec4 projected_pos = u_transform * vec4(a_pos, 1);
     v_dist = projected_pos.w;
     gl_Position = projected_pos;


### PR DESCRIPTION
Uses a simple linear interpolation between the palette RGB color and #000 instead of relying on the COLORMAP lookup tables. Produces a much smoother darkening effect without banding or graying out.

Based on work from my PR #7.