### PR TITLE
Rustup

### DIFF
--- a/src/game/Cargo.toml
+++ b/src/game/Cargo.toml
@@ -24,3 +24,6 @@ path = "../wad"
 
 [dependencies.time]
 git = "https://github.com/rust-lang/time"
+
+[dependencies]
+log = "*"

--- a/src/game/level.rs
+++ b/src/game/level.rs
@@ -101,9 +101,10 @@ const ATLAS_UNIT: uint = 1;
 
 
 macro_rules! offset_of(
-    ($T:ty, $m:ident) =>
-        (unsafe { (&((*(0 as *const $T)).$m)) as *const _ as *const c_void })
-)
+    ($T:ty, $m:ident) => (
+        unsafe { (&((*(0 as *const $T)).$m)) as *const _ as *const c_void }
+    )
+);
 
 
 pub fn build_level(shader_loader: &ShaderLoader,
@@ -370,7 +371,7 @@ impl<'a> VboBuilder<'a> {
                     None => continue
                 };
 
-                let dist = |l: &Line2f| l.signed_distance(&point);
+                let dist = |&: l: &Line2f| l.signed_distance(&point);
 
                 // The intersection point must lie both within the BSP volume
                 // and the segs volume.

--- a/src/game/lib.rs
+++ b/src/game/lib.rs
@@ -229,20 +229,20 @@ pub fn run() {
         .map(|r| {
             let v = r[].splitn(1, 'x').collect::<Vec<&str>>();
             if v.len() != 2 { None } else { Some(v) }
-            .and_then(|v| from_str::<uint>(v[0]).map(|v0| (v0, v[1])))
-            .and_then(|(v0, s)| from_str::<uint>(s).map(|v1| (v0, v1)))
+            .and_then(|v| v[0].parse().map(|v0| (v0, v[1])))
+            .and_then(|(v0, s)| s.parse().map(|v1| (v0, v1)))
             .expect("Invalid format for resolution, please use WIDTHxHEIGHT.")
         })
         .unwrap_or((1280, 720));
     let level_index = matches
         .opt_str("l")
-        .map(|l| from_str::<uint>(l[])
-            .expect("Invalid value for --level. Expected integer."))
+        .map(|l| l[].parse()
+                    .expect("Invalid value for --level. Expected integer."))
         .unwrap_or(0);
     let fov = matches
         .opt_str("f")
-        .map(|f| from_str::<f32>(f[])
-             .expect("Invalid value for --fov. Expected float."))
+        .map(|f| f[].parse()
+                    .expect("Invalid value for --fov. Expected float."))
         .unwrap_or(65.0);
 
     if matches.opt_present("h") {

--- a/src/gfx/Cargo.toml
+++ b/src/gfx/Cargo.toml
@@ -15,3 +15,6 @@ path = "../math"
 
 [dependencies.base]
 path = "../base"
+
+[dependencies]
+log = "*"

--- a/src/gfx/shader.rs
+++ b/src/gfx/shader.rs
@@ -25,11 +25,12 @@ impl ShaderLoader {
     }
 
     pub fn load(&self, name: &str) -> Result<Shader, String> {
-        let name = name.to_string();
-        let frag_src = self.version_directive +
-            try!(read_utf8_file(&self.root_path.join(name + ".frag")))[];
-        let vert_src = self.version_directive +
-            try!(read_utf8_file(&self.root_path.join(name + ".vert")))[];
+        debug!("Loading shader: {}", name);
+        let frag_src = self.version_directive.clone() +
+            try!(read_utf8_file(&self.root_path.join(name.to_string() + ".frag")))[];
+        let vert_src = self.version_directive.clone() +
+            try!(read_utf8_file(&self.root_path.join(name.to_string() + ".vert")))[];
+        debug!("Shader '{}' loaded successfully", name);
         Shader::new_from_source(vert_src[], frag_src[])
     }
 }

--- a/src/gl/Cargo.toml
+++ b/src/gl/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 name = "gl"
 path = "lib.rs"
 
-[dependencies.gl_generator]
+[build-dependencies.gl_generator]
+git = "https://github.com/bjz/gl-rs"
+
+[dependencies.gl_common]
 git = "https://github.com/bjz/gl-rs"
 

--- a/src/gl/Cargo.toml
+++ b/src/gl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gl"
 version = "0.0.1"
 authors = ["Cristian Cobzarenco <cristi.cobzarenco@gmail.com>"]
+build = "build.rs"
 
 [lib]
 name = "gl"

--- a/src/gl/build.rs
+++ b/src/gl/build.rs
@@ -1,0 +1,20 @@
+extern crate gl_generator;
+extern crate khronos_api;
+
+use std::os;
+use std::io::File;
+
+fn main() {
+    let dest = Path::new(os::getenv("OUT_DIR").unwrap());
+    let mut file = File::create(&dest.join("gl_bindings.rs")).unwrap();
+
+    let version = if cfg!(target_os = "linux") { "3.0" } else { "3.3" };
+
+    gl_generator::generate_bindings(gl_generator::GlobalGenerator,
+                                    gl_generator::registry::Ns::Gl,
+                                    khronos_api::GL_XML,
+                                    vec![],
+                                    version,
+                                    "core",
+                                    &mut file).unwrap();
+}

--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -7,21 +7,7 @@
 #[phase(plugin)]
 extern crate gl_generator;
 
-#[cfg(target_os = "linux")]
-generate_gl_bindings! {
-    api: "gl",
-    profile: "core",
-    version: "3.0",
-    generator: "global",
-}
-
-#[cfg(not(target_os = "linux"))]
-generate_gl_bindings! {
-    api: "gl",
-    profile: "core",
-    version: "3.3",
-    generator: "global",
-}
+include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 
 #[cfg(target_os = "linux")]
 pub mod platform {

--- a/src/gl/lib.rs
+++ b/src/gl/lib.rs
@@ -77,7 +77,7 @@ macro_rules! check_gl(
     ::gl::check::check_gl_helper(file!(), line!(), stringify!($func));
     ret
   });
-)
+);
 
 #[macro_export]
 macro_rules! check_gl_unsafe (
@@ -86,4 +86,4 @@ macro_rules! check_gl_unsafe (
     ::gl::check::check_gl_helper(file!(), line!(), stringify!($func));
     ret
   }});
-)
+);

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -129,7 +129,7 @@ impl fmt::Show for Mat4 {
 }
 
 impl Mul<Mat4, Mat4> for Mat4 {
-    fn mul(&self, rhs: &Mat4) -> Mat4 {
+    fn mul(self, rhs: Mat4) -> Mat4 {
         let l = &self.data;
         let r = &rhs.data;
         Mat4 { data:[

--- a/src/math/numvec.rs
+++ b/src/math/numvec.rs
@@ -7,8 +7,8 @@ pub type Vec2f = Vec2<f32>;
 pub type Vec3f = Vec3<f32>;
 pub type Vec4f = Vec4<f32>;
 
-pub trait Numvec<T : Float + FloatMath>
-        : Add<Self, Self> + Mul<T, Self> + Div<T, Self> {
+pub trait Numvec<T : Float + FloatMath + Copy>
+        : Add<Self, Self> + Mul<T, Self> + Div<T, Self> + Copy {
     fn dot(&self, other : &Self) -> T;
 
     fn squared_norm(&self) -> T { self.dot(self) }
@@ -56,23 +56,23 @@ impl<T : Float + FloatMath> Numvec<T> for Vec2<T> {
     }
 }
 impl<T : Float + FloatMath> Add<Vec2<T>, Vec2<T>> for Vec2<T> {
-    fn add(&self, rhs : &Vec2<T>) -> Vec2<T> {
+    fn add(self, rhs : Vec2<T>) -> Vec2<T> {
         return Vec2::new(self.x + rhs.x, self.y + rhs.y);
     }
 }
 impl<T : Float + FloatMath> Sub<Vec2<T>, Vec2<T>> for Vec2<T> {
-    fn sub(&self, rhs : &Vec2<T>) -> Vec2<T> {
+    fn sub(self, rhs : Vec2<T>) -> Vec2<T> {
         return Vec2::new(self.x - rhs.x, self.y - rhs.y);
     }
 }
 impl<T : Float + FloatMath> Mul<T, Vec2<T>> for Vec2<T> {
-    fn mul(&self, rhs : &T) -> Vec2<T> {
-        return Vec2::new(self.x * *rhs, self.y * *rhs);
+    fn mul(self, rhs : T) -> Vec2<T> {
+        return Vec2::new(self.x * rhs, self.y * rhs);
     }
 }
 impl<T : Float + FloatMath> Div<T, Vec2<T>> for Vec2<T> {
-    fn div(&self, rhs : &T) -> Vec2<T> {
-        return Vec2::new(self.x / *rhs, self.y / *rhs);
+    fn div(self, rhs : T) -> Vec2<T> {
+        return Vec2::new(self.x / rhs, self.y / rhs);
     }
 }
 impl<T : Float + FloatMath> Neg<Vec2<T>> for Vec2<T> {
@@ -115,23 +115,23 @@ impl<T : Float + FloatMath> Numvec<T> for Vec3<T> {
     }
 }
 impl<T : Float + FloatMath> Add<Vec3<T>, Vec3<T>> for Vec3<T> {
-    fn add(&self, rhs : &Vec3<T>) -> Vec3<T> {
+    fn add(self, rhs : Vec3<T>) -> Vec3<T> {
         return Vec3::new(self.x + rhs.x, self.y + rhs.y, self.z + rhs.z);
     }
 }
 impl<T : Float + FloatMath> Sub<Vec3<T>, Vec3<T>> for Vec3<T> {
-    fn sub(&self, rhs : &Vec3<T>) -> Vec3<T> {
+    fn sub(self, rhs : Vec3<T>) -> Vec3<T> {
         return Vec3::new(self.x - rhs.x, self.y - rhs.y, self.z - rhs.z);
     }
 }
 impl<T : Float + FloatMath> Mul<T, Vec3<T>> for Vec3<T> {
-    fn mul(&self, rhs : &T) -> Vec3<T> {
-        return Vec3::new(self.x * *rhs, self.y * *rhs, self.z * *rhs);
+    fn mul(self, rhs : T) -> Vec3<T> {
+        return Vec3::new(self.x * rhs, self.y * rhs, self.z * rhs);
     }
 }
 impl<T : Float + FloatMath> Div<T, Vec3<T>> for Vec3<T> {
-    fn div(&self, rhs : &T) -> Vec3<T> {
-        return Vec3::new(self.x / *rhs, self.y / *rhs, self.z / *rhs);
+    fn div(self, rhs : T) -> Vec3<T> {
+        return Vec3::new(self.x / rhs, self.y / rhs, self.z / rhs);
     }
 }
 impl<T : Float + FloatMath> Neg<Vec3<T>> for Vec3<T> {
@@ -186,27 +186,27 @@ impl<T : Float + FloatMath> Numvec<T> for Vec4<T> {
     }
 }
 impl<T : Float + FloatMath> Add<Vec4<T>, Vec4<T>> for Vec4<T> {
-    fn add(&self, rhs : &Vec4<T>) -> Vec4<T> {
+    fn add(self, rhs : Vec4<T>) -> Vec4<T> {
         return Vec4::new(self.x + rhs.x, self.y + rhs.y, self.z + rhs.z,
                          self.w + rhs.w);
     }
 }
 impl<T : Float + FloatMath> Sub<Vec4<T>, Vec4<T>> for Vec4<T> {
-    fn sub(&self, rhs : &Vec4<T>) -> Vec4<T> {
+    fn sub(self, rhs : Vec4<T>) -> Vec4<T> {
         return Vec4::new(self.x - rhs.x, self.y - rhs.y, self.z - rhs.z,
                          self.w - rhs.w);
     }
 }
 impl<T : Float + FloatMath> Mul<T, Vec4<T>> for Vec4<T> {
-    fn mul(&self, rhs : &T) -> Vec4<T> {
-        return Vec4::new(self.x * *rhs, self.y * *rhs, self.z * *rhs,
-                         self.w * *rhs);
+    fn mul(self, rhs : T) -> Vec4<T> {
+        return Vec4::new(self.x * rhs, self.y * rhs, self.z * rhs,
+                         self.w * rhs);
     }
 }
 impl<T : Float + FloatMath> Div<T, Vec4<T>> for Vec4<T> {
-    fn div(&self, rhs : &T) -> Vec4<T> {
-        return Vec4::new(self.x / *rhs, self.y / *rhs, self.z / *rhs,
-                         self.w / *rhs);
+    fn div(self, rhs : T) -> Vec4<T> {
+        return Vec4::new(self.x / rhs, self.y / rhs, self.z / rhs,
+                         self.w / rhs);
     }
 }
 impl<T : Float + FloatMath> Neg<Vec4<T>> for Vec4<T> {

--- a/src/math/numvec.rs
+++ b/src/math/numvec.rs
@@ -76,7 +76,7 @@ impl<T : Float + FloatMath> Div<T, Vec2<T>> for Vec2<T> {
     }
 }
 impl<T : Float + FloatMath> Neg<Vec2<T>> for Vec2<T> {
-    fn neg(&self) -> Vec2<T> {
+    fn neg(self) -> Vec2<T> {
         return Vec2::new(-self.x, -self.y);
     }
 }
@@ -135,7 +135,7 @@ impl<T : Float + FloatMath> Div<T, Vec3<T>> for Vec3<T> {
     }
 }
 impl<T : Float + FloatMath> Neg<Vec3<T>> for Vec3<T> {
-    fn neg(&self) -> Vec3<T> {
+    fn neg(self) -> Vec3<T> {
         return Vec3::new(-self.x, -self.y, -self.z);
     }
 }
@@ -210,7 +210,7 @@ impl<T : Float + FloatMath> Div<T, Vec4<T>> for Vec4<T> {
     }
 }
 impl<T : Float + FloatMath> Neg<Vec4<T>> for Vec4<T> {
-    fn neg(&self) -> Vec4<T> {
+    fn neg(self) -> Vec4<T> {
         return Vec4::new(-self.x, -self.y, -self.z, -self.w);
     }
 }

--- a/src/wad/Cargo.toml
+++ b/src/wad/Cargo.toml
@@ -27,3 +27,5 @@ git = "https://github.com/rust-lang/time"
 
 [dependencies]
 rustc-serialize = "*"
+log = "*"
+regex = "*"

--- a/src/wad/Cargo.toml
+++ b/src/wad/Cargo.toml
@@ -24,3 +24,6 @@ git = "https://github.com/alexcrichton/toml-rs"
 
 [dependencies.time]
 git = "https://github.com/rust-lang/time"
+
+[dependencies]
+rustc-serialize = "*"

--- a/src/wad/image.rs
+++ b/src/wad/image.rs
@@ -17,7 +17,7 @@ pub struct Image {
 
 macro_rules! io_try(
     ($e:expr) => (try!($e.map_err(|e| String::from_str(e.desc))))
-)
+);
 
 
 impl Image {

--- a/src/wad/level.rs
+++ b/src/wad/level.rs
@@ -57,14 +57,14 @@ impl Level {
         let sectors = sectors;
 
         info!("Loaded level '{}':", name);
-        info!("    {:4} things", things.len())
-        info!("    {:4} linedefs", linedefs.len())
-        info!("    {:4} sidedefs", sidedefs.len())
-        info!("    {:4} vertices", vertices.len())
-        info!("    {:4} segs", segs.len())
-        info!("    {:4} subsectors", subsectors.len())
-        info!("    {:4} nodes", nodes.len())
-        info!("    {:4} sectors", sectors.len())
+        info!("    {:4} things", things.len());
+        info!("    {:4} linedefs", linedefs.len());
+        info!("    {:4} sidedefs", sidedefs.len());
+        info!("    {:4} vertices", vertices.len());
+        info!("    {:4} segs", segs.len());
+        info!("    {:4} subsectors", subsectors.len());
+        info!("    {:4} nodes", nodes.len());
+        info!("    {:4} sectors", sectors.len());
 
         Level {
             things: things,

--- a/src/wad/lib.rs
+++ b/src/wad/lib.rs
@@ -12,7 +12,7 @@ extern crate math;
 extern crate log;
 #[phase(plugin, link)]
 extern crate regex;
-extern crate serialize;
+extern crate "rustc-serialize" as rustc_serialize;
 extern crate time;
 extern crate toml;
 

--- a/src/wad/meta.rs
+++ b/src/wad/meta.rs
@@ -1,6 +1,6 @@
 use base;
 use regex::Regex;
-use serialize;
+use rustc_serialize;
 use super::name::WadName;
 use super::types::ThingType;
 use toml;
@@ -8,7 +8,7 @@ use toml::{DecodeError, ApplicationError, ExpectedField, ExpectedType,
            ExpectedMapElement, ExpectedMapKey, NoEnumVariants, NilTooLong};
 
 
-#[deriving(Decodable, Encodable)]
+#[deriving(RustcDecodable, RustcEncodable)]
 pub struct SkyMetadata {
     pub texture_name: WadName,
     pub level_pattern: String,
@@ -16,14 +16,14 @@ pub struct SkyMetadata {
 }
 
 
-#[deriving(Decodable, Encodable)]
+#[deriving(RustcDecodable, RustcEncodable)]
 pub struct AnimationMetadata {
     pub flats: Vec<Vec<WadName>>,
     pub walls: Vec<Vec<WadName>>,
 }
 
 
-#[deriving(Decodable, Encodable)]
+#[deriving(RustcDecodable, RustcEncodable)]
 pub struct ThingMetadata {
     pub thing_type: ThingType,
     pub sprite: WadName,
@@ -31,13 +31,13 @@ pub struct ThingMetadata {
 }
 
 
-#[deriving(Decodable, Encodable)]
+#[deriving(RustcDecodable, RustcEncodable)]
 pub struct ThingDirectoryMetadata {
     pub decoration: Vec<ThingMetadata>
 }
 
 
-#[deriving(Decodable, Encodable)]
+#[deriving(RustcDecodable, RustcEncodable)]
 pub struct WadMetadata {
     pub sky: Vec<SkyMetadata>,
     pub animations: AnimationMetadata,
@@ -52,7 +52,7 @@ impl WadMetadata {
     pub fn from_text(text: &str) -> Result<WadMetadata, String> {
         let mut parser = toml::Parser::new(text);
         match parser.parse() {
-            Some(value) => serialize::Decodable::decode(
+            Some(value) => rustc_serialize::Decodable::decode(
                     &mut toml::Decoder::new(toml::Value::Table(value)))
                 .map_err(|e| show_decode_err(e)),
             None => Err(format!("Error parsing WadMetadata from TOML: {}",

--- a/src/wad/name.rs
+++ b/src/wad/name.rs
@@ -83,31 +83,7 @@ pub trait WadNameCast : Show {
 }
 impl<'a> WadNameCast for &'a [u8,.. 8] {
     fn to_wad_name_opt(&self) -> Option<WadName> {
-        let mut name = [0u8, ..8];
-        let mut nulled = false;
-        for (dest, src) in name.iter_mut().zip(self.iter()) {
-            let new_byte = match src.to_ascii_opt() {
-                Some(ascii) => match ascii.to_uppercase().as_byte() {
-                    b@b'A'...b'Z' | b@b'0'...b'9' | b@b'_' | b@b'-' |
-                    b@b'[' | b@b']' | b@b'\\' => b,
-                    b'\0' => { nulled = true; break },
-                    b => {
-                        debug!("Bailed on ascii {}", b);
-                        return None;
-                    }
-                },
-                None => {
-                    debug!("Bailed on non-ascii {}", src);
-                    return None;
-                }
-            };
-            *dest = new_byte;
-        }
-        if !nulled && self.len() > 8 {
-            debug!("Bailed on '{}' {} {}", str::from_utf8(*self),
-                                           self.len(), !nulled);
-            return None; }
-        Some(WadName { packed: unsafe { mem::transmute(name) } })
+        self[].to_wad_name_opt()
     }
 }
 impl<'a> WadNameCast for &'a [u8] {

--- a/src/wad/name.rs
+++ b/src/wad/name.rs
@@ -1,13 +1,13 @@
 use std::{fmt, mem, str};
 use std::fmt::Show;
 use std::string::String;
-use serialize::{Encoder, Encodable, Decoder, Decodable};
+use rustc_serialize::{Encoder, Encodable, Decoder, Decodable};
 
 #[deriving(Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct WadName { packed: u64 }
 impl WadName {
     pub fn as_str_opt(&self) -> Option<&str> {
-        str::from_utf8(self.as_bytes())
+        str::from_utf8(self.as_bytes()).ok()
     }
 
     pub fn as_str(&self) -> &str {

--- a/src/wad/name.rs
+++ b/src/wad/name.rs
@@ -81,6 +81,35 @@ pub trait WadNameCast : Show {
         }
     }
 }
+impl<'a> WadNameCast for &'a [u8,.. 8] {
+    fn to_wad_name_opt(&self) -> Option<WadName> {
+        let mut name = [0u8, ..8];
+        let mut nulled = false;
+        for (dest, src) in name.iter_mut().zip(self.iter()) {
+            let new_byte = match src.to_ascii_opt() {
+                Some(ascii) => match ascii.to_uppercase().as_byte() {
+                    b@b'A'...b'Z' | b@b'0'...b'9' | b@b'_' | b@b'-' |
+                    b@b'[' | b@b']' | b@b'\\' => b,
+                    b'\0' => { nulled = true; break },
+                    b => {
+                        debug!("Bailed on ascii {}", b);
+                        return None;
+                    }
+                },
+                None => {
+                    debug!("Bailed on non-ascii {}", src);
+                    return None;
+                }
+            };
+            *dest = new_byte;
+        }
+        if !nulled && self.len() > 8 {
+            debug!("Bailed on '{}' {} {}", str::from_utf8(*self),
+                                           self.len(), !nulled);
+            return None; }
+        Some(WadName { packed: unsafe { mem::transmute(name) } })
+    }
+}
 impl<'a> WadNameCast for &'a [u8] {
     fn to_wad_name_opt(&self) -> Option<WadName> {
         let mut name = [0u8, ..8];

--- a/src/wad/tex.rs
+++ b/src/wad/tex.rs
@@ -42,7 +42,7 @@ pub struct TextureDirectory {
 
 macro_rules! io_try(
     ($e:expr) => (try!($e.map_err(|e| String::from_str(e.desc))))
-)
+);
 
 fn search_for_frame<'a>(search_for: &WadName, animations: &'a Vec<Vec<WadName>>)
         -> Option<&'a [WadName]> {

--- a/src/wad/types.rs
+++ b/src/wad/types.rs
@@ -193,7 +193,7 @@ macro_rules! size_tests(
             )+
         }
     )
-)
+);
 
 size_tests! {
     WadInfo = 12,


### PR DESCRIPTION
This will likely fail travis as it's still pending on a fix in rust-sdl2 but you can use a local override in the meantime.

There's a lot of additional cloning on some of the string additions due to a bug in the stdlib at the moment, e.g. `"foo" + "bar".to_string()` = `"barfoo"`.