### PR TITLE
Fix one-off animation bug

### DIFF
--- a/src/game/level.rs
+++ b/src/game/level.rs
@@ -124,7 +124,7 @@ enum Peg {
     BottomFloat
 }
 
-#[repr(C, packed)]
+#[repr(packed)]
 #[derive(Copy, Clone)]
 struct StaticVertex {
     _pos: Vec3f,
@@ -132,12 +132,12 @@ struct StaticVertex {
     _tile_uv: Vec2f,
     _tile_size: Vec2f,
     _scroll_rate: f32,
+    _row_height: f32,
     _num_frames: u8,
-    _frame_offset: u8,
     _light: u8,
 }
 
-#[repr(C, packed)]
+#[repr(packed)]
 #[derive(Copy, Clone)]
 struct SpriteVertex {
     _pos: Vec3f,
@@ -146,11 +146,10 @@ struct SpriteVertex {
     _tile_size: Vec2f,
     _local_x: f32,
     _num_frames: u8,
-    _frame_offset: u8,
     _light: u8,
 }
 
-#[repr(C, packed)]
+#[repr(packed)]
 #[derive(Copy, Clone)]
 struct SkyVertex {
     _pos: Vec3f,

--- a/src/game/level.rs
+++ b/src/game/level.rs
@@ -412,8 +412,8 @@ impl<'a> VboBuilder<'a> {
             .attribute_vec2f(2, offset_of!(StaticVertex, _tile_uv))
             .attribute_vec2f(3, offset_of!(StaticVertex, _tile_size))
             .attribute_f32(4, offset_of!(StaticVertex, _scroll_rate))
-            .attribute_u8(5, offset_of!(StaticVertex, _num_frames))
-            .attribute_u8(6, offset_of!(StaticVertex, _frame_offset))
+            .attribute_f32(5, offset_of!(StaticVertex, _row_height))
+            .attribute_u8(6, offset_of!(StaticVertex, _num_frames))
             .attribute_u8(7, offset_of!(StaticVertex, _light));
         buffer.build()
     }
@@ -426,8 +426,7 @@ impl<'a> VboBuilder<'a> {
             .attribute_vec2f(3, offset_of!(SpriteVertex, _tile_size))
             .attribute_f32(4, offset_of!(SpriteVertex, _local_x))
             .attribute_u8(5, offset_of!(SpriteVertex, _num_frames))
-            .attribute_u8(6, offset_of!(SpriteVertex, _frame_offset))
-            .attribute_u8(7, offset_of!(SpriteVertex, _light));
+            .attribute_u8(6, offset_of!(SpriteVertex, _light));
         buffer.build()
     }
 
@@ -784,7 +783,7 @@ impl<'a> VboBuilder<'a> {
             _tile_size: bounds.size,
             _scroll_rate: 0.0,
             _num_frames: bounds.num_frames as u8,
-            _frame_offset: bounds.frame_offset as u8,
+            _row_height: bounds.row_height as f32,
             _light: light_info,
         });
     }
@@ -798,7 +797,7 @@ impl<'a> VboBuilder<'a> {
             _tile_size: bounds.size,
             _scroll_rate: scroll_rate,
             _num_frames: bounds.num_frames as u8,
-            _frame_offset: bounds.frame_offset as u8,
+            _row_height: bounds.row_height as f32,
             _light: light_info,
         });
     }
@@ -812,7 +811,6 @@ impl<'a> VboBuilder<'a> {
             _tile_uv: Vec2::new(tile_u, tile_v),
             _tile_size: bounds.size,
             _num_frames: 1,
-            _frame_offset: 0,
             _light: light_info,
         };
         self.decors.push(v);

--- a/src/math/numvec.rs
+++ b/src/math/numvec.rs
@@ -24,7 +24,7 @@ pub trait Numvec<T: Float + Copy>
     }
 }
 
-#[repr(C, packed)]
+#[repr(packed)]
 #[derive(PartialEq, Copy, Clone)]
 pub struct Vec2<T: Float + Sized + PartialEq> {
     pub x: T,
@@ -96,7 +96,7 @@ impl<T: Float  + Debug> Debug for Vec2<T> {
 }
 
 
-#[repr(C, packed)]
+#[repr(packed)]
 #[derive(PartialEq, Copy, Clone)]
 pub struct Vec3<T: Float + Sized + PartialEq> {
     pub x: T,
@@ -175,7 +175,7 @@ impl<T: Float + Debug> Debug for Vec3<T> {
 }
 
 
-#[repr(C, packed)]
+#[repr(packed)]
 #[derive(PartialEq, Copy, Clone)]
 pub struct Vec4<T: Float + Sized + PartialEq> {
     pub x: T,

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -10,8 +10,7 @@ layout(location = 2) in vec2 a_tile_uv;
 layout(location = 3) in vec2 a_tile_size;
 layout(location = 4) in float a_local_x;
 layout(location = 5) in int a_num_frames;
-layout(location = 6) in int a_frame_offset;
-layout(location = 7) in int a_light;
+layout(location = 6) in int a_light;
 
 out float v_dist;
 out vec2 v_tile_uv;
@@ -26,7 +25,7 @@ void main() {
     if (a_num_frames == 1) {
       v_atlas_uv = a_atlas_uv;
     } else {
-        float frame_index = u_time / ANIM_FPS + float(a_frame_offset);
+        float frame_index = u_time / ANIM_FPS;
         frame_index = floor(mod(frame_index, float(a_num_frames)));
 
         float atlas_u = a_atlas_uv.x + frame_index * a_tile_size.x;

--- a/src/shaders/static.vert
+++ b/src/shaders/static.vert
@@ -10,8 +10,8 @@ layout(location = 1) in vec2 a_atlas_uv;
 layout(location = 2) in vec2 a_tile_uv;
 layout(location = 3) in vec2 a_tile_size;
 layout(location = 4) in float a_scroll_rate;
-layout(location = 5) in int a_num_frames;
-layout(location = 6) in int a_frame_offset;
+layout(location = 5) in float a_row_height;
+layout(location = 6) in int a_num_frames;
 layout(location = 7) in int a_light;
 
 out float v_dist;
@@ -27,7 +27,7 @@ void main() {
     if (a_num_frames == 1) {
       v_atlas_uv = a_atlas_uv;
     } else {
-        float frame_index = u_time / ANIM_FPS + float(a_frame_offset);
+        float frame_index = u_time / ANIM_FPS;
         frame_index = floor(mod(frame_index, float(a_num_frames)));
 
         float atlas_u = a_atlas_uv.x + frame_index * a_tile_size.x;
@@ -37,7 +37,7 @@ void main() {
         // TODO(cristicbz): * a_tile_size.y below isn't quite correct if the tile is smaller in
         // height than the row size. As it happens, all animated tiles happen to be 128.0 so this
         // works...
-        float atlas_v = a_atlas_uv.y + n_rows_down * a_tile_size.y;
+        float atlas_v = a_atlas_uv.y + n_rows_down * a_row_height;
         v_atlas_uv = vec2(atlas_u, atlas_v);
     }
     v_tile_size = a_tile_size;

--- a/src/wad/image.rs
+++ b/src/wad/image.rs
@@ -4,6 +4,8 @@ use gl;
 use std::ptr::copy_nonoverlapping;
 use std::vec::Vec;
 use types::WadTextureHeader;
+use sdl2::pixels::PixelFormatEnum;
+use std::path::Path;
 
 pub struct Image {
     width: usize,
@@ -164,22 +166,23 @@ impl Image {
 
     pub fn pixels(&self) -> &[u16] { &self.pixels }
 
-    // Commented out due to a bug in SDL2.
-    //pub fn save_bmp(&self, palette: &[[u8; 3]; 256]) {
-    //    use ::sdl2::surface::Surface;
-    //    let mut pixels = vec![0u8; 3 * self.width * self.height];
-    //    for (index, pixel) in self.pixels.iter().enumerate() {
-    //        let pixel = palette[(pixel & 0xff) as usize];
-    //        pixels[index * 3] = pixel[2];
-    //        pixels[index * 3 + 1] = pixel[1];
-    //        pixels[index * 3 + 2] = pixel[0];
-    //    }
-    //    Surface::from_data(&mut pixels[..], self.width as i32, self.height as i32,
-    //                       24, self.width as i32 * 3,
-    //                       0xff0000, 0x00ff00, 0x0000ff, 0x0)
-    //        .unwrap()
-    //        .save_bmp("/home/cristi/temp.bmp".as_ref())
-    //        .unwrap();
-    //}
+    pub fn save_bmp<P: AsRef<Path>>(&self, palette: &[[u8; 3]; 256], path: &P) {
+        use ::sdl2::surface::Surface;
+        let mut pixels = vec![0u8; 3 * self.width * self.height];
+        for (index, pixel) in self.pixels.iter().enumerate() {
+            let pixel = palette[(pixel & 0xff) as usize];
+            pixels[index * 3] = pixel[2];
+            pixels[index * 3 + 1] = pixel[1];
+            pixels[index * 3 + 2] = pixel[0];
+        }
+        Surface::from_data(&mut pixels[..],
+                           self.width as u32,
+                           self.height as u32,
+                           self.width as u32 * 3,
+                           PixelFormatEnum::BGR24)
+            .unwrap()
+            .save_bmp(path)
+            .unwrap();
+    }
 }
 

--- a/src/wad/tex.rs
+++ b/src/wad/tex.rs
@@ -24,7 +24,7 @@ pub struct Bounds {
     pub pos: Vec2f,
     pub size: Vec2f,
     pub num_frames: usize,
-    pub frame_offset: usize,
+    pub row_height: usize,
 }
 
 pub type BoundsLookup = BTreeMap<WadName, Bounds>;
@@ -187,11 +187,16 @@ impl TextureDirectory {
             }
         };
 
-        fn img_bound((x_offset, y_offset): (isize, isize), img: &Image,
-                     frame_offset: usize, num_frames: usize) -> Bounds {
-            Bounds { pos: Vec2::new(x_offset as f32, y_offset as f32),
-                     size: Vec2::new(img.width() as f32, img.height() as f32),
-                     num_frames: num_frames, frame_offset: frame_offset }
+        fn img_bound((x_offset, y_offset, row_height): (isize, isize, usize),
+                     img: &Image,
+                     num_frames: usize)
+                    -> Bounds {
+            Bounds {
+                pos: Vec2::new(x_offset as f32, y_offset as f32),
+                size: Vec2::new(img.width() as f32, img.height() as f32),
+                num_frames: num_frames,
+                row_height: row_height
+            }
         }
 
 
@@ -218,7 +223,7 @@ impl TextureDirectory {
                     failed = true;
                     break;
                 }
-                offsets.push((x_offset as isize, y_offset as isize));
+                offsets.push((x_offset as isize, y_offset as isize, max_height as usize));
                 x_offset += width;
             }
 
@@ -246,8 +251,10 @@ impl TextureDirectory {
         let mut bound_map = BTreeMap::new();
         for (i, (name, image, frame_offset, num_frames)) in images.into_iter().enumerate() {
             atlas.blit(image, offsets[i].0, offsets[i].1, true);
-            bound_map.insert(*name, img_bound(offsets[i - frame_offset],
-                                              image, frame_offset, num_frames));
+            bound_map.insert(*name,
+                             img_bound(offsets[i - frame_offset],
+                                       image,
+                                       num_frames));
         }
 
         let mut tex = Texture::new(gl::TEXTURE_2D);
@@ -290,7 +297,7 @@ impl TextureDirectory {
                 pos: anim_start_pos,
                 size: Vec2::new(64.0, 64.0),
                 num_frames: num_frames,
-                frame_offset: frame_offset
+                row_height: 64,
             });
 
             for y in 0 .. 64 {


### PR DESCRIPTION
I put a TODO in one of the shaders saying 'this is technically incorrect, but...`. Turns out the but was wrong and the bug would be triggered only for a particular ordering of the textures in the atlas; to avoid these heisenbugs, I also switched atlas building to use a BTreeMap for determinstic ordering.