### PR TITLE
Fix some fallout from rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+reorder_imports = true

--- a/src/game/ctrl.rs
+++ b/src/game/ctrl.rs
@@ -3,7 +3,7 @@ use num::Zero;
 use sdl2::event::Event;
 use sdl2::keyboard::Scancode;
 use sdl2::mouse::{Mouse, MouseUtil};
-use sdl2::{Sdl, EventPump};
+use sdl2::{EventPump, Sdl};
 use std::vec::Vec;
 
 pub type Sensitivity = f32;
@@ -123,9 +123,7 @@ impl GameController {
                 true
             }
             Gesture::NoGesture => false,
-            _ => {
-                panic!("Unimplemented gesture type.");
-            }
+            _ => panic!("Unimplemented gesture type."),
         }
     }
 

--- a/src/game/level.rs
+++ b/src/game/level.rs
@@ -5,12 +5,12 @@ use num::Zero;
 use std::error::Error;
 use wad::tex::BoundsLookup;
 use wad::tex::{OpaqueImage, TransparentImage};
-use wad::types::{WadName, SectorId};
-use wad::util::{from_wad_coords, is_untextured, is_sky_flat};
-use wad::{WadMetadata, SkyMetadata, TextureDirectory};
+use wad::types::{SectorId, WadName};
+use wad::util::{from_wad_coords, is_sky_flat, is_untextured};
+use wad::{SkyMetadata, TextureDirectory, WadMetadata};
 use wad::Archive;
 use wad::Level as WadLevel;
-use wad::{LightInfo, LevelWalker, LevelVisitor};
+use wad::{LevelVisitor, LevelWalker, LightInfo};
 
 pub struct Level {
     start_pos: Vec3f,

--- a/src/game/lights.rs
+++ b/src/game/lights.rs
@@ -1,4 +1,4 @@
-use wad::{LightInfo, LightEffectKind};
+use wad::{LightEffectKind, LightInfo};
 
 pub struct LightBuffer {
     lights: Vec<LightInfo>,

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -2,7 +2,7 @@ use camera::Camera;
 use ctrl::{Analog2d, Gesture};
 use ctrl::GameController;
 use level::Level;
-use math::{Vec3f, Vec2f, Vector};
+use math::{Vec2f, Vec3f, Vector};
 use sdl2::keyboard::Scancode;
 use std::default::Default;
 use num::{Float, Zero};

--- a/src/gfx/error.rs
+++ b/src/gfx/error.rs
@@ -1,5 +1,5 @@
 use std::error::Error as StdError;
-use std::fmt::{Formatter, Display};
+use std::fmt::{Display, Formatter};
 use std::fmt::Result as FmtResult;
 use std::io::Error as IoError;
 use std::result::Result as StdResult;
@@ -189,6 +189,7 @@ impl<S> NeededBy for StdResult<S, glium::DrawError> {
                     feature: format!("{:?}", e),
                     needed_by: by.to_owned(),
                 },
+
                 e@NoDepthBuffer |
                 e@AttributeTypeMismatch |
                 e@AttributeMissing |

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -9,11 +9,11 @@ extern crate libc;
 extern crate sdl2;
 extern crate glium_sdl2;
 
-pub use error::{Result, Error};
-pub use window::Window;
+pub use error::{Error, Result};
 pub use scene::{Scene, SceneBuilder};
-pub use vertex::{StaticBuffer, StaticVertex, SpriteBuffer, SpriteVertex, SkyBuffer, SkyVertex};
-pub use vertex::{FlatBufferBuilder, WallBufferBuilder, DecorBufferBuilder, SkyBufferBuilder};
+pub use window::Window;
+pub use vertex::{SkyBuffer, SkyVertex, SpriteBuffer, SpriteVertex, StaticBuffer, StaticVertex};
+pub use vertex::{DecorBufferBuilder, FlatBufferBuilder, SkyBufferBuilder, WallBufferBuilder};
 
 mod error;
 mod platform;

--- a/src/gfx/scene.rs
+++ b/src/gfx/scene.rs
@@ -1,11 +1,11 @@
-use error::{Result, NeededBy};
-use glium::{Depth, DepthTest, BackfaceCullingMode, Program, DrawParameters, Frame, Surface};
+use error::{NeededBy, Result};
+use glium::{BackfaceCullingMode, Depth, DepthTest, DrawParameters, Frame, Program, Surface};
 use glium::index::{NoIndices, PrimitiveType};
-use glium::texture::{Texture2d, RawImage2d, ClientFormat};
+use glium::texture::{ClientFormat, RawImage2d, Texture2d};
 use glium::texture::buffer_texture::{BufferTexture, BufferTextureType};
-use glium::uniforms::{SamplerBehavior, MinifySamplerFilter, MagnifySamplerFilter};
+use glium::uniforms::{MagnifySamplerFilter, MinifySamplerFilter, SamplerBehavior};
 use glium::uniforms::SamplerWrapFunction;
-use glium::uniforms::{Uniforms, UniformValue, AsUniformValue};
+use glium::uniforms::{AsUniformValue, UniformValue, Uniforms};
 use math::{Mat4, Vec2};
 use platform;
 use std::borrow::Cow;
@@ -13,8 +13,8 @@ use std::fs::File;
 use std::io::Read;
 use std::io::Result as IoResult;
 use std::path::{Path, PathBuf};
-use vertex::{FlatBufferBuilder, WallBufferBuilder, SkyBufferBuilder, DecorBufferBuilder};
-use vertex::{StaticBuffer, SkyBuffer, SpriteBuffer};
+use vertex::{DecorBufferBuilder, FlatBufferBuilder, SkyBufferBuilder, WallBufferBuilder};
+use vertex::{SkyBuffer, SpriteBuffer, StaticBuffer};
 use window::Window;
 
 pub struct SceneBuilder<'window> {

--- a/src/gfx/vertex.rs
+++ b/src/gfx/vertex.rs
@@ -1,5 +1,5 @@
 use Bounds;
-use error::{Result, NeededBy};
+use error::{NeededBy, Result};
 use glium::VertexBuffer;
 use math::{Vec2f, Vec3f};
 use Window;

--- a/src/gfx/window.rs
+++ b/src/gfx/window.rs
@@ -1,5 +1,5 @@
 use error::Result;
-use glium_sdl2::{SDL2Facade, DisplayBuild};
+use glium_sdl2::{DisplayBuild, SDL2Facade};
 use glium::Frame;
 use platform;
 use sdl2;

--- a/src/math/line.rs
+++ b/src/math/line.rs
@@ -1,5 +1,5 @@
 use num::{Float, NumCast};
-use vector::{Vec2, Vector, Field};
+use vector::{Field, Vec2, Vector};
 
 pub type Line2f = Line2<f32>;
 
@@ -9,17 +9,25 @@ pub struct Line2<T: Copy + Field + Float + NumCast> {
     displace: Vec2<T>,
 }
 impl<T: Copy + Field + Float + NumCast> Line2<T> {
-    pub fn from_origin_and_displace(origin: Vec2<T>,
-                                    displace: Vec2<T>) -> Line2<T> {
-        Line2 { origin: origin, displace: displace.normalized() }
+    pub fn from_origin_and_displace(origin: Vec2<T>, displace: Vec2<T>) -> Line2<T> {
+        Line2 {
+            origin: origin,
+            displace: displace.normalized(),
+        }
     }
 
     pub fn from_two_points(origin: Vec2<T>, towards: Vec2<T>) -> Line2<T> {
-        Line2 { origin: origin, displace: (towards - origin).normalized() }
+        Line2 {
+            origin: origin,
+            displace: (towards - origin).normalized(),
+        }
     }
 
     pub fn inverted_halfspaces(&self) -> Line2<T> {
-        Line2 { origin: self.origin, displace: -self.displace }
+        Line2 {
+            origin: self.origin,
+            displace: -self.displace,
+        }
     }
 
     pub fn signed_distance(&self, to: &Vec2<T>) -> T {

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -1,6 +1,7 @@
+
 use num::Float;
 use std::fmt;
-use std::ops::{Add, Sub, Mul, Index, IndexMut};
+use std::ops::{Add, Index, IndexMut, Mul, Sub};
 
 use vector::{Vec3f, Vector};
 
@@ -18,20 +19,20 @@ pub type Scalar = f32;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Mat4 {
-    data: [Scalar; 16]
+    data: [Scalar; 16],
 }
 
 impl Mat4 {
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn new(m00: Scalar, m01: Scalar, m02: Scalar, m03: Scalar,
                m10: Scalar, m11: Scalar, m12: Scalar, m13: Scalar,
                m20: Scalar, m21: Scalar, m22: Scalar, m23: Scalar,
                m30: Scalar, m31: Scalar, m32: Scalar, m33: Scalar) -> Mat4 {
-        // In my mind vectors are columns, hence matrices need to be transposed
-        // to the OpenGL memory order.
         Mat4 { data: [m00, m10, m20, m30, m01, m11, m21, m31,
                       m02, m12, m22, m32, m03, m13, m23, m33] }
     }
 
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn new_identity() -> Mat4 {
         Mat4::new(1.0, 0.0, 0.0, 0.0,
                   0.0, 1.0, 0.0, 0.0,
@@ -45,6 +46,7 @@ impl Mat4 {
     /// * `fov_degrees`  - Horizontal field of view.
     /// * `aspect_ratio` - Ratio between width and height of the view.
     /// * `near`, `far`  - The Z coordinate of the near and far planes.
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn new_perspective(fov_degrees: Scalar, aspect_ratio: Scalar,
                            near: Scalar, far: Scalar) -> Mat4 {
         let fov = (3.1415926538 * fov_degrees) / 180.0;
@@ -58,6 +60,7 @@ impl Mat4 {
     }
 
     /// Creates a matrix which rotates points by `angle_radians` around `axis`.
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn new_axis_rotation(axis: &Vec3f, angle_radians: Scalar) -> Mat4 {
         let ca = angle_radians.cos();
         let sa = angle_radians.sin();
@@ -72,6 +75,7 @@ impl Mat4 {
     }
 
     /// Creates a rotation matrix from the three _Euler angles_.
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn new_euler_rotation(yaw: f32, pitch: f32, roll: f32) -> Mat4 {
         let (ca, sa) = (pitch.cos(), pitch.sin());
         let (cb, sb) = (yaw.cos(), yaw.sin());
@@ -85,6 +89,7 @@ impl Mat4 {
     }
 
     /// Creates a translation matrix which maps points `p` to `p + by`.
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn new_translation(by: Vec3f) -> Mat4 {
         Mat4::new(1.0, 0.0, 0.0, by[0],
                   0.0, 1.0, 0.0, by[1],
@@ -93,10 +98,9 @@ impl Mat4 {
     }
 
     /// Returns the transpose of the matrix (columns swapped with rows).
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn transposed(&self) -> Mat4 {
         let m = &self.data;
-        // m is in column-major order, so calling with new in row-order will
-        // transpose it.
         Mat4::new(m[0], m[1], m[2], m[3],
                   m[4], m[5], m[6], m[7],
                   m[8], m[9], m[10], m[11],
@@ -117,6 +121,7 @@ impl Mat4 {
 }
 
 impl fmt::Debug for Mat4 {
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter,
                "[{:10.3e} {:10.3e} {:10.3e} {:10.3e};\n\
@@ -133,6 +138,7 @@ impl fmt::Debug for Mat4 {
 impl<'a, 'b> Mul<&'a Mat4> for &'b Mat4 {
     type Output = Mat4;
 
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn mul(self, rhs: &'a Mat4) -> Mat4 {
         let l = &self.data;
         let r = &rhs.data;
@@ -163,6 +169,7 @@ impl<'a, 'b> Mul<&'a Mat4> for &'b Mat4 {
 impl<'a, 'b> Add<&'a Mat4> for &'b Mat4 {
     type Output = Mat4;
 
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn add(self, rhs: &'a Mat4) -> Mat4 {
         let l = &self.data;
         let r = &rhs.data;
@@ -178,6 +185,7 @@ impl<'a, 'b> Add<&'a Mat4> for &'b Mat4 {
 impl<'a, 'b> Sub<&'a Mat4> for &'b Mat4 {
     type Output = Mat4;
 
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn sub(self, rhs: &'a Mat4) -> Mat4 {
         let l = &self.data;
         let r = &rhs.data;
@@ -193,19 +201,25 @@ impl<'a, 'b> Sub<&'a Mat4> for &'b Mat4 {
 impl Mul<Mat4> for Mat4 {
     type Output = Mat4;
 
-    fn mul(self, rhs: Mat4) -> Mat4 { &self * &rhs }
+    fn mul(self, rhs: Mat4) -> Mat4 {
+        &self * &rhs
+    }
 }
 
 impl Add<Mat4> for Mat4 {
     type Output = Mat4;
 
-    fn add(self, rhs: Mat4) -> Mat4 { &self + &rhs }
+    fn add(self, rhs: Mat4) -> Mat4 {
+        &self + &rhs
+    }
 }
 
 impl Sub<Mat4> for Mat4 {
     type Output = Mat4;
 
-    fn sub(self, rhs: Mat4) -> Mat4 { &self - &rhs }
+    fn sub(self, rhs: Mat4) -> Mat4 {
+        &self - &rhs
+    }
 }
 
 impl Index<usize> for Mat4 {
@@ -235,6 +249,7 @@ mod test {
     use super::Mat4;
 
     #[test]
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_mul() {
         let a = Mat4::new(4.0,    8.0,    1.0,    6.0,
                           9.0,    4.0,    2.0,    1.0,

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -1,9 +1,9 @@
-use num::{Float, Zero, One};
-use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
+use num::{Float, One, Zero};
 use std::fmt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::mem;
+use std::ops::{Add, Div, Index, IndexMut, Mul, Neg, Sub};
 
 pub type Vec2f = Vec2<f32>;
 pub type Vec3f = Vec3<f32>;
@@ -37,13 +37,23 @@ pub trait Vector: Mul<<Self as Vector>::Scalar, Output=Self>
     }
 
     #[inline]
-    fn norm(&self) -> Self::Scalar where Self::Scalar: Float { self.squared_norm().sqrt() }
+    fn norm(&self) -> Self::Scalar
+        where Self::Scalar: Float
+    {
+        self.squared_norm().sqrt()
+    }
 
     #[inline]
-    fn normalize(&mut self) where Self::Scalar: Float { *self = self.clone().normalized(); }
+    fn normalize(&mut self)
+        where Self::Scalar: Float
+    {
+        *self = self.clone().normalized();
+    }
 
     #[inline]
-    fn normalized(self) -> Self where Self::Scalar: Float {
+    fn normalized(self) -> Self
+        where Self::Scalar: Float
+    {
         let norm = self.norm();
         self / norm
     }
@@ -67,40 +77,54 @@ pub struct VectorNil<Scalar: Field>(PhantomData<Scalar>);
 impl<Scalar: Field> Mul<Scalar> for VectorNil<Scalar> {
     type Output = Self;
     #[inline]
-    fn mul(self, _rhs: Scalar) -> Self { self }
+    fn mul(self, _rhs: Scalar) -> Self {
+        self
+    }
 }
 
 impl<Scalar: Field> Div<Scalar> for VectorNil<Scalar> {
     type Output = Self;
     #[inline]
-    fn div(self, _rhs: Scalar) -> Self { self }
+    fn div(self, _rhs: Scalar) -> Self {
+        self
+    }
 }
 
 impl<Scalar: Field> Add for VectorNil<Scalar> {
     type Output = Self;
     #[inline]
-    fn add(self, _rhs: Self) -> Self { self }
+    fn add(self, _rhs: Self) -> Self {
+        self
+    }
 }
 
 impl<Scalar: Field> Sub for VectorNil<Scalar> {
     type Output = Self;
     #[inline]
-    fn sub(self, _rhs: Self) -> Self { self }
+    fn sub(self, _rhs: Self) -> Self {
+        self
+    }
 }
 
 impl<Scalar> Neg for VectorNil<Scalar>
         where Scalar: Field + Neg<Output=Scalar> {
     type Output = Self;
     #[inline]
-    fn neg(self) -> Self { self }
+    fn neg(self) -> Self {
+        self
+    }
 }
 
 impl<Scalar: Field> Zero for VectorNil<Scalar> {
     #[inline]
-    fn zero() -> Self { VectorNil(PhantomData) }
+    fn zero() -> Self {
+        VectorNil(PhantomData)
+    }
 
     #[inline]
-    fn is_zero(&self) -> bool { true }
+    fn is_zero(&self) -> bool {
+        true
+    }
 }
 
 impl<Scalar: Field> Index<usize> for VectorNil<Scalar> {
@@ -108,14 +132,16 @@ impl<Scalar: Field> Index<usize> for VectorNil<Scalar> {
 
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
-        panic!("index out of bounds: the len is 0 but the index is {}", index);
+        panic!("index out of bounds: the len is 0 but the index is {}",
+               index);
     }
 }
 
 impl<Scalar: Field> IndexMut<usize> for VectorNil<Scalar> {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        panic!("index out of bounds: the len is 0 but the index is {}", index);
+        panic!("index out of bounds: the len is 0 but the index is {}",
+               index);
     }
 }
 
@@ -123,49 +149,64 @@ impl<Scalar: Field> Vector for VectorNil<Scalar> {
     type Scalar = Scalar;
 
     #[inline]
-    fn dot(&self, _rhs: &Self) -> Scalar { Scalar::zero() }
+    fn dot(&self, _rhs: &Self) -> Scalar {
+        Scalar::zero()
+    }
 
     #[inline]
-    fn get(&self, _index: usize) -> Option<&Scalar> { None }
+    fn get(&self, _index: usize) -> Option<&Scalar> {
+        None
+    }
 
     #[inline]
-    fn get_mut(&mut self, _index: usize) -> Option<&mut Scalar> { None }
+    fn get_mut(&mut self, _index: usize) -> Option<&mut Scalar> {
+        None
+    }
 
     #[inline]
-    fn len(&self) -> usize { 0 }
+    fn len(&self) -> usize {
+        0
+    }
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
-pub struct VectorCons<Scalar, Tail>(Scalar, Tail)
-    where Scalar: Field, Tail: Vector<Scalar=Scalar>;
+pub struct VectorCons<Scalar: Field, Tail: Vector<Scalar = Scalar>>(Scalar, Tail);
 
 impl<Scalar, Tail> Mul<Scalar> for VectorCons<Scalar, Tail>
         where Scalar: Field, Tail: Vector<Scalar=Scalar> {
     type Output = Self;
     #[inline]
-    fn mul(self, rhs: Scalar) -> Self { VectorCons(self.0 * rhs.clone(), self.1 * rhs) }
+    fn mul(self, rhs: Scalar) -> Self {
+        VectorCons(self.0 * rhs.clone(), self.1 * rhs)
+    }
 }
 
 impl<Scalar, Tail> Div<Scalar> for VectorCons<Scalar, Tail>
         where Scalar: Field, Tail: Vector<Scalar=Scalar> {
     type Output = Self;
     #[inline]
-    fn div(self, rhs: Scalar) -> Self { VectorCons(self.0 / rhs.clone(), self.1 / rhs) }
+    fn div(self, rhs: Scalar) -> Self {
+        VectorCons(self.0 / rhs.clone(), self.1 / rhs)
+    }
 }
 
 impl<Scalar, Tail> Add for VectorCons<Scalar, Tail>
         where Scalar: Field, Tail: Vector<Scalar=Scalar> {
     type Output = Self;
     #[inline]
-    fn add(self, rhs: Self) -> Self { VectorCons(self.0 + rhs.0, self.1 + rhs.1) }
+    fn add(self, rhs: Self) -> Self {
+        VectorCons(self.0 + rhs.0, self.1 + rhs.1)
+    }
 }
 
 impl<Scalar, Tail> Sub for VectorCons<Scalar, Tail>
         where Scalar: Field, Tail: Vector<Scalar=Scalar> {
     type Output = Self;
     #[inline]
-    fn sub(self, rhs: Self) -> Self { VectorCons(self.0 - rhs.0, self.1 - rhs.1) }
+    fn sub(self, rhs: Self) -> Self {
+        VectorCons(self.0 - rhs.0, self.1 - rhs.1)
+    }
 }
 
 impl<Scalar, Tail> Neg for VectorCons<Scalar, Tail>
@@ -173,16 +214,22 @@ impl<Scalar, Tail> Neg for VectorCons<Scalar, Tail>
               Tail: Vector<Scalar=Scalar> + Neg<Output=Tail> {
     type Output = Self;
     #[inline]
-    fn neg(self) -> Self { VectorCons(-self.0, -self.1) }
+    fn neg(self) -> Self {
+        VectorCons(-self.0, -self.1)
+    }
 }
 
 impl<Scalar, Tail> Zero for VectorCons<Scalar, Tail>
         where Scalar: Field, Tail: Vector<Scalar=Scalar> {
     #[inline]
-    fn zero() -> Self { VectorCons(Scalar::zero(), Tail::zero()) }
+    fn zero() -> Self {
+        VectorCons(Scalar::zero(), Tail::zero())
+    }
 
     #[inline]
-    fn is_zero(&self) -> bool { self.0.is_zero() && self.1.is_zero() }
+    fn is_zero(&self) -> bool {
+        self.0.is_zero() && self.1.is_zero()
+    }
 }
 
 impl<Scalar, Tail> Index<usize> for VectorCons<Scalar, Tail>
@@ -194,7 +241,8 @@ impl<Scalar, Tail> Index<usize> for VectorCons<Scalar, Tail>
         self.get(index)
             .unwrap_or_else(|| {
                 panic!("index out of bounds: the len is {} but the index is {}",
-                       self.len(), index);
+                       self.len(),
+                       index);
             })
     }
 }
@@ -206,7 +254,9 @@ impl<Scalar, Tail> IndexMut<usize> for VectorCons<Scalar, Tail>
         let len = self.len();
         self.get_mut(index)
             .unwrap_or_else(|| {
-                panic!("index out of bounds: the len is {} but the index is {}", len, index);
+                panic!("index out of bounds: the len is {} but the index is {}",
+                       len,
+                       index);
             })
     }
 }
@@ -221,7 +271,9 @@ impl<Scalar, Tail> Vector for VectorCons<Scalar, Tail>
     }
 
     #[inline]
-    fn len(&self) -> usize { 1 + self.1.len() }
+    fn len(&self) -> usize {
+        1 + self.1.len()
+    }
 
     #[inline]
     fn get(&self, index: usize) -> Option<&Scalar> {
@@ -254,12 +306,16 @@ impl<Scalar: Field> Vec2<Scalar> {
     }
 
     #[inline]
-    pub fn angle(&self) -> Scalar where Scalar: Float {
+    pub fn angle(&self) -> Scalar
+        where Scalar: Float
+    {
         self.0.clone().atan2((self.1).0.clone())
     }
 
     #[inline]
-    pub fn normal(self) -> Vec2<Scalar> where Scalar: Neg<Output=Scalar> {
+    pub fn normal(self) -> Vec2<Scalar>
+        where Scalar: Neg<Output = Scalar>
+    {
         Vec2::new(-(self.1).0, self.0)
     }
 
@@ -281,7 +337,9 @@ impl<Scalar: Field> Vec3<Scalar> {
         let (rx, ry, rz) = (rhs.0, (rhs.1).0, ((rhs.1).1).0);
         let (lx2, ly2, lz2) = (lx.clone(), ly.clone(), lz.clone());
         let (rx2, ry2, rz2) = (rx.clone(), ry.clone(), rz.clone());
-        Vec3::new(ly * rz - lz * ry, lz2 * rx - lx * rz2, lx2 * ry2 - ly2 * rx2)
+        Vec3::new(ly * rz - lz * ry,
+                  lz2 * rx - lx * rz2,
+                  lx2 * ry2 - ly2 * rx2)
     }
 }
 

--- a/src/wad/archive.rs
+++ b/src/wad/archive.rs
@@ -1,12 +1,12 @@
 use error::ErrorKind::{BadWadHeader, MissingRequiredLump};
-use error::{Result, Error, ErrorKind, InFile};
+use error::{Error, ErrorKind, InFile, Result};
 use meta::WadMetadata;
 use read::{WadRead, WadReadFrom};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs::File;
-use std::io::{Seek, SeekFrom, BufReader};
+use std::io::{BufReader, Seek, SeekFrom};
 use std::mem;
 use std::path::Path;
 use std::path::PathBuf;
@@ -14,7 +14,7 @@ use std::result::Result as StdResult;
 use std::vec::Vec;
 use std::borrow::Borrow;
 use std::hash::Hash;
-use types::{WadLump, WadInfo, WadName};
+use types::{WadInfo, WadLump, WadName};
 use util::wad_type_from_info;
 
 pub struct Archive {

--- a/src/wad/error.rs
+++ b/src/wad/error.rs
@@ -5,7 +5,7 @@ use std::error::Error as StdError;
 use std::fmt::{Display, Formatter};
 use std::fmt::Result as FmtResult;
 use std::io::Error as IoError;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 use toml::DecodeError as TomlDecodeError;
 use toml::ParserError as TomlParserError;

--- a/src/wad/level.rs
+++ b/src/wad/level.rs
@@ -2,8 +2,8 @@ use math::Vec2f;
 use std::mem;
 use std::vec::Vec;
 use archive::Archive;
-use types::{WadThing, WadLinedef, WadSidedef, WadVertex, WadSeg, WadSubsector};
-use types::{WadNode, WadSector, VertexId, LightLevel, SectorId};
+use types::{WadLinedef, WadSeg, WadSidedef, WadSubsector, WadThing, WadVertex};
+use types::{LightLevel, SectorId, VertexId, WadNode, WadSector};
 use util::from_wad_coords;
 use error::Result;
 
@@ -150,14 +150,14 @@ impl Level {
         let mut min_light = sector.light;
         let sector_id = self.sector_id(sector);
         for line in &self.linedefs {
-            let (left, right) = (match self.left_sidedef(line) {
+            let left = match self.left_sidedef(line) {
                 Some(l) => l.sector,
                 None => continue,
-            },
-                                 match self.right_sidedef(line) {
+            };
+            let right = match self.right_sidedef(line) {
                 Some(r) => r.sector,
                 None => continue,
-            });
+            };
             let adjacent_light = if left == sector_id {
                 self.sectors.get(right as usize).map(|s| s.light)
             } else if right == sector_id {

--- a/src/wad/lib.rs
+++ b/src/wad/lib.rs
@@ -22,9 +22,9 @@ pub use meta::SkyMetadata;
 pub use meta::ThingMetadata;
 pub use name::WadName;
 pub use tex::TextureDirectory;
-pub use error::{Result, Error};
+pub use error::{Error, Result};
 pub use visitor::{LevelVisitor, LevelWalker};
-pub use light::{LightInfo, LightEffect, LightEffectKind};
+pub use light::{LightEffect, LightEffectKind, LightInfo};
 
 mod name;
 mod archive;

--- a/src/wad/light.rs
+++ b/src/wad/light.rs
@@ -1,5 +1,5 @@
 use level::Level;
-use types::{SectorType, WadSector, LightLevel};
+use types::{LightLevel, SectorType, WadSector};
 
 #[derive(PartialEq, Clone)]
 pub struct LightInfo {

--- a/src/wad/meta.rs
+++ b/src/wad/meta.rs
@@ -1,12 +1,12 @@
 use error::ErrorKind::BadMetadataSyntax;
-use error::{Result, InFile};
+use error::{InFile, Result};
 use name::WadName;
 use regex::Regex;
-use rustc_serialize::{Encodable, Decodable};
+use rustc_serialize::{Decodable, Encodable};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use toml::{Decoder, Value, Parser};
+use toml::{Decoder, Parser, Value};
 use types::ThingType;
 
 #[derive(Debug, RustcDecodable, RustcEncodable)]

--- a/src/wad/name.rs
+++ b/src/wad/name.rs
@@ -1,7 +1,7 @@
-use error::{Result, ErrorKind};
+use error::{ErrorKind, Result};
 use std::result::Result as StdResult;
-use read::{WadReadFrom, WadRead};
-use rustc_serialize::{Encoder, Encodable, Decoder, Decodable};
+use read::{WadRead, WadReadFrom};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::ascii::AsciiExt;
 use std::fmt;
 use std::fmt::Debug;

--- a/src/wad/read.rs
+++ b/src/wad/read.rs
@@ -1,4 +1,4 @@
-use byteorder::{LittleEndian, ByteOrder, ReadBytesExt};
+use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use error::Result;
 use std::io::Read;
 use std::io::Error as IoError;

--- a/src/wad/types.rs
+++ b/src/wad/types.rs
@@ -1,5 +1,5 @@
 use error::Result;
-use read::{WadReadFrom, WadRead};
+use read::{WadRead, WadReadFrom};
 use std::io::Read;
 
 pub use super::name::WadName;

--- a/src/wad/util.rs
+++ b/src/wad/util.rs
@@ -1,5 +1,5 @@
 use math::{Vec2, Vec2f};
-use types::{WadCoord, WadInfo, WadName, ChildId};
+use types::{ChildId, WadCoord, WadInfo, WadName};
 
 #[derive(Copy, Clone)]
 pub enum WadType {


### PR DESCRIPTION
There were some things that rustfmt didn't do great in #60, I reorganized some of the code so that rustfmt could be ran without any manual fixups. Henceforth, all commits should use rustfmt before being merged.