### PR TITLE
Lighting and SRGB fixes, add visit_marker to LevelVisitor

### DIFF
--- a/src/game/lights.rs
+++ b/src/game/lights.rs
@@ -21,9 +21,9 @@ impl LightBuffer {
             }) as u8
     }
 
-    pub fn fill_buffer_at(&mut self, time: f32, buffer: &mut [f32]) {
+    pub fn fill_buffer_at(&mut self, time: f32, buffer: &mut [u8]) {
         for (value, info) in buffer.iter_mut().zip(self.lights.iter()) {
-            *value = light_level_at(info, time);
+            *value = (clamp(light_level_at(info, time)) * 255.0) as u8;
         }
     }
 }
@@ -63,4 +63,14 @@ fn noise(sync: f32, time: f32) -> f32 {
 
 fn fract(x: f32) -> f32 {
     x - x.floor()
+}
+
+fn clamp(x: f32) -> f32 {
+    if x < 0.0 {
+        0.0
+    } else if x > 1.0 {
+        1.0
+    } else {
+        x
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ impl RunMode {
                                                                  .unwrap_or("1280x720"
                                                                                 .to_owned())));
             let fov = try!(matches.opt_str("fov")
-                                  .unwrap_or("65".to_owned())
+                                  .unwrap_or("64".to_owned())
                                   .parse::<f32>()
                                   .map_err(|_| GeneralError("invalid value for fov".into())));
             let level = try!(matches.opt_str("level")

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -14,7 +14,6 @@ flat in float v_light;
 
 const float DIST_SCALE = 1.0;
 const float LIGHT_SCALE = 2.0;
-const float LIGHT_BIAS = 1e-4;
 
 void main() {
     vec2 uv = mod(v_tile_uv, v_tile_size) + v_atlas_uv;
@@ -24,7 +23,6 @@ void main() {
     } else {
         float dist_term = min(1.0, 1.0 - DIST_SCALE / (v_dist + DIST_SCALE));
         float light = min(v_light, v_light * LIGHT_SCALE - dist_term);
-        light = clamp(1.0 - light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
-        color = texture(u_palette, vec2(palette_index.r, light)).rgb;
+        color = texture(u_palette, vec2(palette_index.r, 1.0 - light)).rgb;
     }
 }

--- a/src/shaders/static.frag
+++ b/src/shaders/static.frag
@@ -12,9 +12,8 @@ flat in vec2 v_atlas_uv;
 flat in vec2 v_tile_size;
 flat in float v_light;
 
-const float DIST_SCALE = 1.0;
+const float DIST_SCALE = 0.9;
 const float LIGHT_SCALE = 2.0;
-const float LIGHT_BIAS = 1e-4;
 
 void main() {
     vec2 uv = mod(v_tile_uv, v_tile_size) + v_atlas_uv;
@@ -23,8 +22,7 @@ void main() {
         discard;
     } else {
         float dist_term = min(1.0, 1.0 - DIST_SCALE / (v_dist + DIST_SCALE));
-        float light = min(v_light, v_light * LIGHT_SCALE - dist_term);
-        light = clamp(1.0 - light, LIGHT_BIAS, 1.0 - LIGHT_BIAS);
-        color = texture(u_palette, vec2(palette_index.r, light)).rgb;
+        float light = v_light * LIGHT_SCALE - dist_term;
+        color = texture(u_palette, vec2(palette_index.r, 1.0 - light)).rgb;
     }
 }

--- a/src/wad/lib.rs
+++ b/src/wad/lib.rs
@@ -23,7 +23,7 @@ pub use meta::ThingMetadata;
 pub use name::WadName;
 pub use tex::TextureDirectory;
 pub use error::{Error, Result};
-pub use visitor::{LevelVisitor, LevelWalker, Branch};
+pub use visitor::{LevelVisitor, LevelWalker, Branch, Marker};
 pub use light::{LightEffect, LightEffectKind, LightInfo};
 
 mod name;


### PR DESCRIPTION
Three unrelated changes:
  * move start position lookup in LevelWalker and feed it to the visitor using a new `visit_marker`.
  * use SRGB everywhere to fix the 'washed out' look on SRGB framebuffer capable devices.
  * simplify and tweak lighting equation to make it closer to original (tested by alt-tabbing back and forth between rust-doom and chocolate-doom)