### PR TITLE
Fix Unofficial Doom Specs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rust Doom
 
 A little Doom 1 & 2 Renderer written in [Rust](https://github.com/rust-lang/rust). Mostly written while I was learning the language about 2 years ago, so it might not the best example of Rust code! PR-s are welcome.
 
-The code is mostly based on the endlessly useful [Doom Wiki](http://doomwiki.org) and the [Unofficial Doom Specs](http://aiforge.net/test/wadview/dmspec16.txt). It is **not** a port of the original Doom C source code into Rust; I've been doing my best to make the code as idiomatic as possible and have not looked at the original in a long time.
+The code is mostly based on the endlessly useful [Doom Wiki](http://doomwiki.org) and the [Unofficial Doom Specs](http://www.gamers.org/dhs/helpdocs/dmsp1666.html). It is **not** a port of the original Doom C source code into Rust; I've been doing my best to make the code as idiomatic as possible and have not looked at the original in a long time.
 
 *Note: You need a WAD file to try this. Get a [shareware one](http://www.pc-freak.net/files/doom-wad-files/Doom1.WAD) if you don't own the game.*
 


### PR DESCRIPTION
The current link does not work because aiforge.net no longer exists.